### PR TITLE
Update README to reflect use of Lead Channel in API spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ All fields are optional according to the API specification. The app will only se
 
 ## Documentation
 
-See the `docs/` folder for:
-- `openapi.yml` - Complete API specification for the Rechat Lead Capture API
+See the [`docs/`](/docs/) folder for:
+
+- [`openapi.yml`](/docs/openapi.yml) - Complete API specification for the Rechat Lead Capture API
 
 ## Contact Rechat
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ All fields are optional according to the API specification. The app will only se
 
 ## Documentation
 
-See the `docs/` folder for:
-- `openapi.yml` - Complete API specification for the Rechat Lead Capture API
+See the [`docs/`](/docs/) folder for:
+
+- [`openapi.yml`](/docs/openapi.yml) - Complete API specification for the Rechat Lead Capture API
 
 ## Contact Rechat
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple form application to test the Rechat Lead Capture API integration with a
 
 - Complete form with all API fields (all optional)
 - Configurable API key input
-- Configurable unique endpoint ID
+- Configurable lead channel ID
 - Real-time API testing
 - Response display
 - Docker containerization support
@@ -30,42 +30,42 @@ A simple form application to test the Rechat Lead Capture API integration with a
 ### Local Development
 
 1. Install dependencies:
-\`\`\`bash
+```bash
 npm install
-\`\`\`
+```
 
-2. Run the development server:
-\`\`\`bash
+1. Run the development server:
+```bash
 npm run dev
-\`\`\`
+```
 
-3. Open [http://localhost:3000](http://localhost:3000) in your browser
+1. Open [http://localhost:3000](http://localhost:3000) in your browser
 
 ### Docker
 
 1. Build the Docker image:
-\`\`\`bash
+```bash
 docker build -t rechat-lead-demo .
-\`\`\`
+```
 
-2. Run the container:
-\`\`\`bash
+1. Run the container:
+```bash
 docker run -p 3000:3000 rechat-lead-demo
-\`\`\`
+```
 
-3. Open [http://localhost:3000](http://localhost:3000) in your browser
+1. Open [http://localhost:3000](http://localhost:3000) in your browser
 
 ## Configuration
 
-- **Unique Endpoint ID**: Default is `54a57918-ad9b-4adb-a35a-9232bf78d734`
+- **Lead Channel**: Default is `54a57918-ad9b-4adb-a35a-9232bf78d734`
 - **API Key**: Optional, can be entered in the form
 - **Default Values**: Pre-filled with demo values for testing
 
 ## API Integration
 
-The form submits to: `https://api.rechat.com/leads/channels/{unique_endpoint_id}/webhook`
+The form submits to: `https://api.rechat.com/leads/channels/{lead_channel}/webhook`
 
-All fields are optional according to the API specification. The app will only send fields that have values.
+All fields except for `source_type` are optional according to the API specification. The app will only send fields that have values.
 
 ## Documentation
 
@@ -75,6 +75,6 @@ See the [`docs/`](/docs/) folder for:
 
 ## Contact Rechat
 
-For production use, contact [Rechat's support team](https://help.rechat.com/appendix/contacting-support) to obtain your unique endpoint URL and integration guidance.
+For production use, contact [Rechat's support team](https://help.rechat.com/appendix/contacting-support) for integration guidance.
 
 For more information about lead capture integration, visit the [Rechat documentation](https://help.rechat.com/appendix/brokerage-set-up/lead-capture).


### PR DESCRIPTION
Depends on #1. Updates README to reflect the use of `lead_channel` rather than `unique_endpoint_id`.